### PR TITLE
Fix the command to run the test cases for the lesson

### DIFF
--- a/lessons/02/exercises/tests/04_state_transition_enum.rs
+++ b/lessons/02/exercises/tests/04_state_transition_enum.rs
@@ -1,4 +1,4 @@
-//! Run this file with `cargo test --test 03_state_transition_enum`.
+//! Run this file with `cargo test --test 04_state_transition_enum`.
 
 // The #[derive] attribute enables nicer error messages in tests.
 // It will be explained in later weeks.


### PR DESCRIPTION
The command to run the test cases for 4th exercise in 2nd lesson was incorrect. Changed it to avoid confusion. 